### PR TITLE
ordering by import member name instead of path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-import { IStyleAPI, IStyleItem } from 'import-sort-style';
-
 import { IImport } from 'import-sort-parser';
+import { IStyleAPI, IStyleItem } from 'import-sort-style';
 
 const hasAlias = (aliases: string[]) => (imported: IImport) =>
   aliases.some((alias: string): boolean => imported.moduleName.includes(alias));
@@ -28,7 +27,8 @@ export default (
 
   const isAliasModule = hasAlias(options.alias || []);
 
-  const eslintSort = (first, second) => unicode(first.toLowerCase(), second.toLowerCase());
+  const eslintSort = (first, second) =>
+    unicode(first.toLowerCase(), second.toLowerCase());
 
   return [
     // import 'module';
@@ -78,7 +78,7 @@ export default (
     // relative Modules
     {
       match: isRelativeModule,
-      sort: [dotSegmentCount, moduleName(eslintSort)],
+      sort: member(eslintSort),
       sortNamedMembers: alias(eslintSort)
     },
     {
@@ -87,7 +87,7 @@ export default (
     // relative Modules
     {
       match: isRelativeModule,
-      sort: [dotSegmentCount, moduleName(eslintSort)]
+      sort: member(eslintSort)
     }
   ];
 };

--- a/test/fixtures/all-the-things.ts
+++ b/test/fixtures/all-the-things.ts
@@ -35,15 +35,15 @@ import { TodoModule } from '@app/modules/todo/todo.module';
 import { DialogModule } from '@app/shared/components/dialog';
 import { SharedModule } from '@app/shared/shared.module';
 
-import { SummariesComponent } from './components/summaries/summaries.component';
-import { SummariesApiService } from './shared/summaries-api.service';
-import { SummariesResolver } from './shared/summaries.resolver';
 import { SummariesActions } from './store/summaries.actions';
+import { SummariesApiService } from './shared/summaries-api.service';
+import { SummariesComponent } from './components/summaries/summaries.component';
 import { SummariesEffects } from './store/summaries.effects';
 import {
   summariesReducer,
   summariesStatePath,
 } from './store/summaries.reducer';
-import { SummariesSelectors } from './store/summaries.selectors';
+import { SummariesResolver } from './shared/summaries.resolver';
 import { SummariesRoutingModule } from './summaries-routing.module';
-`.trim() + '\n';
+import { SummariesSelectors } from './store/summaries.selectors';
+`.trim() + "\n";

--- a/test/fixtures/all-the-things.ts
+++ b/test/fixtures/all-the-things.ts
@@ -46,4 +46,4 @@ import {
 import { SummariesResolver } from './shared/summaries.resolver';
 import { SummariesRoutingModule } from './summaries-routing.module';
 import { SummariesSelectors } from './store/summaries.selectors';
-`.trim() + "\n";
+`.trim() + '\n';

--- a/test/fixtures/internal-modules.ts
+++ b/test/fixtures/internal-modules.ts
@@ -9,7 +9,7 @@ import { SiblingComponent } from './sibling-component';
 import { ParentComponent } from '../../parent/parent-component';
 import { SharedService } from '../../../shared/services/shared-service';
 import { AAStartsWithARelativeNearbyImport } from './shared';
-`.trim() + "\n";
+`.trim() + '\n';
 
 export const expected =
   `
@@ -23,4 +23,4 @@ import { ParentComponent } from '../../parent/parent-component';
 import { SharedComponent } from '../../shared/components/component';
 import { SharedService } from '../../../shared/services/shared-service';
 import { SiblingComponent } from './sibling-component';
-`.trim() + "\n";
+`.trim() + '\n';

--- a/test/fixtures/internal-modules.ts
+++ b/test/fixtures/internal-modules.ts
@@ -8,7 +8,7 @@ import { SharedComponent } from '../../shared/components/component';
 import { SiblingComponent } from './sibling-component';
 import { ParentComponent } from '../../parent/parent-component';
 import { SharedService } from '../../../shared/services/shared-service';
-import { AAAAFromOtherFolderButStillRelative } from './shared';
+import { AAStartsWithARelativeNearbyImport } from './shared';
 `.trim() + "\n";
 
 export const expected =
@@ -18,7 +18,7 @@ import { logoutPath } from '@app/core/auth/shared/auth-constants';
 import { invoke } from '@app/utils';
 import { environment } from '@environments/environment';
 
-import { AAAAFromOtherFolderButStillRelative } from './shared';
+import { AAStartsWithARelativeNearbyImport } from './shared';
 import { ParentComponent } from '../../parent/parent-component';
 import { SharedComponent } from '../../shared/components/component';
 import { SharedService } from '../../../shared/services/shared-service';

--- a/test/fixtures/internal-modules.ts
+++ b/test/fixtures/internal-modules.ts
@@ -8,7 +8,8 @@ import { SharedComponent } from '../../shared/components/component';
 import { SiblingComponent } from './sibling-component';
 import { ParentComponent } from '../../parent/parent-component';
 import { SharedService } from '../../../shared/services/shared-service';
-`.trim() + '\n';
+import { AAAAFromOtherFolderButStillRelative } from './shared';
+`.trim() + "\n";
 
 export const expected =
   `
@@ -17,8 +18,9 @@ import { logoutPath } from '@app/core/auth/shared/auth-constants';
 import { invoke } from '@app/utils';
 import { environment } from '@environments/environment';
 
-import { SharedService } from '../../../shared/services/shared-service';
+import { AAAAFromOtherFolderButStillRelative } from './shared';
 import { ParentComponent } from '../../parent/parent-component';
 import { SharedComponent } from '../../shared/components/component';
+import { SharedService } from '../../../shared/services/shared-service';
 import { SiblingComponent } from './sibling-component';
-`.trim() + '\n';
+`.trim() + "\n";


### PR DESCRIPTION
This will change the sort order for relative imports to be based on the name of the imported member rather than the path.

i.e.
```
import { a } from ./
import { b } from ../../
import { c } from ../../../
```

instead of 
```
import { c } from ../../../
import { b } from ../../
import { a } from ./
```
