### PR TITLE
Feature/return to dot order then alphabetize

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-import { IStyleAPI, IStyleItem } from 'import-sort-style';
-
 import { IImport } from 'import-sort-parser';
+import { IStyleAPI, IStyleItem } from 'import-sort-style';
 
 const hasAlias = (aliases: string[]) => (imported: IImport) =>
   aliases.some((alias: string): boolean => imported.moduleName.includes(alias));
@@ -13,6 +12,7 @@ export default (
   const {
     alias,
     and,
+    dotSegmentCount,
     hasNamespaceMember,
     hasNoMember,
     isAbsoluteModule,
@@ -77,7 +77,7 @@ export default (
     // relative Modules
     {
       match: isRelativeModule,
-      sort: member(eslintSort),
+      sort: [dotSegmentCount, member(eslintSort)],
       sortNamedMembers: alias(eslintSort)
     },
     {
@@ -86,7 +86,7 @@ export default (
     // relative Modules
     {
       match: isRelativeModule,
-      sort: member(eslintSort)
+      sort: [dotSegmentCount, member(eslintSort)]
     }
   ];
 };

--- a/test/fixtures/internal-modules.ts
+++ b/test/fixtures/internal-modules.ts
@@ -8,7 +8,9 @@ import { SharedComponent } from '../../shared/components/component';
 import { SiblingComponent } from './sibling-component';
 import { ParentComponent } from '../../parent/parent-component';
 import { SharedService } from '../../../shared/services/shared-service';
-import { AAStartsWithARelativeNearbyImport } from './shared';
+import { A } from './shared';
+import { a } from './shared';
+import { b } from './shared';
 `.trim() + '\n';
 
 export const expected =
@@ -18,9 +20,11 @@ import { logoutPath } from '@app/core/auth/shared/auth-constants';
 import { invoke } from '@app/utils';
 import { environment } from '@environments/environment';
 
-import { AAStartsWithARelativeNearbyImport } from './shared';
+import { SharedService } from '../../../shared/services/shared-service';
 import { ParentComponent } from '../../parent/parent-component';
 import { SharedComponent } from '../../shared/components/component';
-import { SharedService } from '../../../shared/services/shared-service';
+import { A } from './shared';
+import { a } from './shared';
+import { b } from './shared';
 import { SiblingComponent } from './sibling-component';
 `.trim() + '\n';

--- a/test/fixtures/internal-modules.ts
+++ b/test/fixtures/internal-modules.ts
@@ -28,3 +28,23 @@ import { a } from './shared';
 import { b } from './shared';
 import { SiblingComponent } from './sibling-component';
 `.trim() + '\n';
+
+export const code2 =
+  `
+import { A } from ./
+import { A } from ../../
+import { A } from ../../../
+import { a } from ./
+import { b } from ../../
+import { c } from ../../../
+`.trim() + '\n';
+
+export const expected2 =
+  `
+import { A } from ../../../
+import { c } from ../../../
+import { A } from ../../
+import { b } from ../../
+import { A } from ./
+import { a } from ./
+`.trim() + '\n';

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,10 +1,9 @@
 import 'mocha';
 
+import { assert } from 'chai';
+import { applyChanges, sortImports } from 'import-sort';
 import * as parser from 'import-sort-parser-typescript';
 
-import { applyChanges, sortImports } from 'import-sort';
-
-import { assert } from 'chai';
 import moduleAliasGroupingStyle from '../src';
 
 describe('sortImports', () => {
@@ -26,48 +25,62 @@ describe('sortImports', () => {
     assert.equal(applyChanges(code, changes), expected);
   });
 
-  it('should sort external libraries', async()=>{
+  it('should sort external libraries', async () => {
     const { code, expected } = await import('./fixtures/external-modules');
     const result = sortImports(
       code,
       parser,
       moduleAliasGroupingStyle,
-      undefined,
+      undefined
     );
     const actual = result.code;
     const changes = result.changes;
 
     assert.equal(actual, expected);
     assert.equal(applyChanges(code, changes), expected);
-  })
+  });
 
-  it('should sort scoped internal libraries', async()=>{
-    const { code, expected } = await import('./fixtures/internal-modules');
+  it('should sort scoped internal libraries', async () => {
+    const { code, expected, code2, expected2 } = await import(
+      './fixtures/internal-modules'
+    );
     const result = sortImports(
       code,
       parser,
       moduleAliasGroupingStyle,
-      undefined,
+      undefined
     );
-    const actual = result.code;
-    const changes = result.changes;
+    let actual = result.code;
+    let changes = result.changes;
 
     assert.equal(actual, expected);
     assert.equal(applyChanges(code, changes), expected);
-  })
 
-  it('should alphabetize named imports', async()=>{
+    const result2 = sortImports(
+      code2,
+      parser,
+      moduleAliasGroupingStyle,
+      undefined
+    );
+    actual = result2.code;
+    changes = result2.changes;
+
+    assert.equal(actual, expected2);
+    assert.equal(applyChanges(code2, changes), expected2);
+  });
+
+  it('should alphabetize named imports', async () => {
     const { code, expected } = await import('./fixtures/named-imports');
     const result = sortImports(
       code,
       parser,
       moduleAliasGroupingStyle,
-      undefined,
+      undefined
     );
     const actual = result.code;
     const changes = result.changes;
 
     assert.equal(actual, expected);
     assert.equal(applyChanges(code, changes), expected);
-  })
+  });
 });


### PR DESCRIPTION
This will change the sort order for relative imports to be based on the dot notation first, then alphabetize based on the member.

before
```
import { A } from ./
import { A } from ../../
import { A } from ../../../
import { a } from ./
import { b } from ../../
import { c } from ../../../
```

after:
```
import { A } from ../../../
import { c } from ../../../
import { A } from ../../
import { b } from ../../
import { A } from ./
import { a } from ./
```