### PR TITLE
revert changes to relative imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,7 @@ export default (
 
   const isAliasModule = hasAlias(options.alias || []);
 
-  const eslintSort = (first, second) =>
-    unicode(first.toLowerCase(), second.toLowerCase());
+  const eslintSort = (first, second) => unicode(first.toLowerCase(), second.toLowerCase());
 
   return [
     // import 'module';
@@ -77,7 +76,7 @@ export default (
     // relative Modules
     {
       match: isRelativeModule,
-      sort: [dotSegmentCount, member(eslintSort)],
+      sort: [dotSegmentCount, moduleName(eslintSort)],
       sortNamedMembers: alias(eslintSort)
     },
     {
@@ -86,7 +85,7 @@ export default (
     // relative Modules
     {
       match: isRelativeModule,
-      sort: [dotSegmentCount, member(eslintSort)]
+      sort: [dotSegmentCount, moduleName(eslintSort)]
     }
   ];
 };

--- a/test/fixtures/all-the-things.ts
+++ b/test/fixtures/all-the-things.ts
@@ -35,15 +35,15 @@ import { TodoModule } from '@app/modules/todo/todo.module';
 import { DialogModule } from '@app/shared/components/dialog';
 import { SharedModule } from '@app/shared/shared.module';
 
-import { SummariesActions } from './store/summaries.actions';
-import { SummariesApiService } from './shared/summaries-api.service';
 import { SummariesComponent } from './components/summaries/summaries.component';
+import { SummariesApiService } from './shared/summaries-api.service';
+import { SummariesResolver } from './shared/summaries.resolver';
+import { SummariesActions } from './store/summaries.actions';
 import { SummariesEffects } from './store/summaries.effects';
 import {
   summariesReducer,
   summariesStatePath,
 } from './store/summaries.reducer';
-import { SummariesResolver } from './shared/summaries.resolver';
-import { SummariesRoutingModule } from './summaries-routing.module';
 import { SummariesSelectors } from './store/summaries.selectors';
+import { SummariesRoutingModule } from './summaries-routing.module';
 `.trim() + '\n';

--- a/test/fixtures/internal-modules.ts
+++ b/test/fixtures/internal-modules.ts
@@ -8,9 +8,6 @@ import { SharedComponent } from '../../shared/components/component';
 import { SiblingComponent } from './sibling-component';
 import { ParentComponent } from '../../parent/parent-component';
 import { SharedService } from '../../../shared/services/shared-service';
-import { A } from './shared';
-import { a } from './shared';
-import { b } from './shared';
 `.trim() + '\n';
 
 export const expected =
@@ -23,28 +20,5 @@ import { environment } from '@environments/environment';
 import { SharedService } from '../../../shared/services/shared-service';
 import { ParentComponent } from '../../parent/parent-component';
 import { SharedComponent } from '../../shared/components/component';
-import { A } from './shared';
-import { a } from './shared';
-import { b } from './shared';
 import { SiblingComponent } from './sibling-component';
-`.trim() + '\n';
-
-export const code2 =
-  `
-import { A } from ./
-import { A } from ../../
-import { A } from ../../../
-import { a } from ./
-import { b } from ../../
-import { c } from ../../../
-`.trim() + '\n';
-
-export const expected2 =
-  `
-import { A } from ../../../
-import { c } from ../../../
-import { A } from ../../
-import { b } from ../../
-import { A } from ./
-import { a } from ./
 `.trim() + '\n';

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,9 +1,10 @@
 import 'mocha';
 
-import { assert } from 'chai';
-import { applyChanges, sortImports } from 'import-sort';
 import * as parser from 'import-sort-parser-typescript';
 
+import { applyChanges, sortImports } from 'import-sort';
+
+import { assert } from 'chai';
 import moduleAliasGroupingStyle from '../src';
 
 describe('sortImports', () => {
@@ -25,62 +26,48 @@ describe('sortImports', () => {
     assert.equal(applyChanges(code, changes), expected);
   });
 
-  it('should sort external libraries', async () => {
+  it('should sort external libraries', async()=>{
     const { code, expected } = await import('./fixtures/external-modules');
     const result = sortImports(
       code,
       parser,
       moduleAliasGroupingStyle,
-      undefined
+      undefined,
     );
     const actual = result.code;
     const changes = result.changes;
 
     assert.equal(actual, expected);
     assert.equal(applyChanges(code, changes), expected);
-  });
+  })
 
-  it('should sort scoped internal libraries', async () => {
-    const { code, expected, code2, expected2 } = await import(
-      './fixtures/internal-modules'
-    );
+  it('should sort scoped internal libraries', async()=>{
+    const { code, expected } = await import('./fixtures/internal-modules');
     const result = sortImports(
       code,
       parser,
       moduleAliasGroupingStyle,
-      undefined
+      undefined,
     );
-    let actual = result.code;
-    let changes = result.changes;
+    const actual = result.code;
+    const changes = result.changes;
 
     assert.equal(actual, expected);
     assert.equal(applyChanges(code, changes), expected);
+  })
 
-    const result2 = sortImports(
-      code2,
-      parser,
-      moduleAliasGroupingStyle,
-      undefined
-    );
-    actual = result2.code;
-    changes = result2.changes;
-
-    assert.equal(actual, expected2);
-    assert.equal(applyChanges(code2, changes), expected2);
-  });
-
-  it('should alphabetize named imports', async () => {
+  it('should alphabetize named imports', async()=>{
     const { code, expected } = await import('./fixtures/named-imports');
     const result = sortImports(
       code,
       parser,
       moduleAliasGroupingStyle,
-      undefined
+      undefined,
     );
     const actual = result.code;
     const changes = result.changes;
 
     assert.equal(actual, expected);
     assert.equal(applyChanges(code, changes), expected);
-  });
+  })
 });


### PR DESCRIPTION
Recent updates were incorrect.  

relative imports should lint by path name then module name. 
